### PR TITLE
Update assume role policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,10 @@ data "aws_iam_policy_document" "assume_role_policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["codedeploy.amazonaws.com"]
+      identifiers = [
+        "codedeploy.amazonaws.com",
+        "ecs-tasks.amazonaws.com"
+      ]
     }
   }
 }


### PR DESCRIPTION
When attempting to use CodeDeploy Blue/Green deployment using this module I face this error:
> error ECS was unable to assume the role 'arn:aws:iam::ACCOUNT:role/SERVICE-ecs-codedeploy' that was provided for this task. Please verify that the role being passed has the proper trust relationship and permissions and that your IAM user has permissions to pass this role

Reading [this](https://stackoverflow.com/a/49016565/7528718) article I found out that a trust relationship is needed with ecs-tasks.amazonaws.com for this role to be assumed during CodeDeploy Blue/Green deployments.

After making this change to the trust relationship the Deployment was successful.